### PR TITLE
Fixed time import in library and delays in loops in examples.

### DIFF
--- a/circuitpython_examples/2_loop_digit_simple/2_loop_digit_simple.py
+++ b/circuitpython_examples/2_loop_digit_simple/2_loop_digit_simple.py
@@ -18,4 +18,4 @@ while True:
     my_tube.set_digit(count)
 
     count = (count + 1) % 10
-time.sleep(1)
+    time.sleep(1)

--- a/circuitpython_library/exixe.py
+++ b/circuitpython_library/exixe.py
@@ -14,7 +14,7 @@ EXIXE_ANIMATION_IN_PROGRESS = 1
 EXIXE_ANIMATION_FINISHED = 0
 MAX_BRIGHTNESS = 127
 
-millis = lambda: int(round(time.time() * 1000))
+millis = lambda: int(round(time.monotonic() * 1000))
 
 
 def cap_digit(digit):
@@ -162,6 +162,7 @@ class Exixe:
         if current_frame > self.animation_duration:
             self.animation_src_digit = self.animation_dest_digit
             self.animation_in_progress = False
+            self.set_digit(self.animation_src_digit, self.animation_brightness)
             return EXIXE_ANIMATION_FINISHED
         self.clear_digit()
         self.set_en_bit_to_1()


### PR DESCRIPTION
Fixed the time lambda. Circuit python does not support time.time(). 
Fixed 2_loop_digit examples delay, it was past the loop. 
Fixed tube animation not fully turning off old digit in certain cases. 